### PR TITLE
Update architect-orb to 2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@0.4.5
+  architect: giantswarm/architect@2.1.0
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.3.0
 
 version: 2.1
 jobs:

--- a/helm/dns-network-policy-operator/Chart.yaml
+++ b/helm/dns-network-policy-operator/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 name: dns-network-policy-operator
 version: [[ .Version ]]
 appVersion: "[[ .AppVersion ]]"
+description: dns-network-policy-operator manages Kubernetes network policies with DNS-based egress rules support.
+home: https://github.com/giantswarm/dns-network-policy-operator

--- a/helm/dns-network-policy-operator/Chart.yaml
+++ b/helm/dns-network-policy-operator/Chart.yaml
@@ -1,3 +1,4 @@
 apiVersion: v1
 name: dns-network-policy-operator
 version: [[ .Version ]]
+appVersion: [[ .Version ]]

--- a/helm/dns-network-policy-operator/Chart.yaml
+++ b/helm/dns-network-policy-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: dns-network-policy-operator
 version: [[ .Version ]]
-appVersion: [[ .Version ]]
+appVersion: "[[ .AppVersion ]]"

--- a/helm/dns-network-policy-operator/templates/deployment.yaml
+++ b/helm/dns-network-policy-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: {{ .Values.project.name }}
         version: {{ .Values.project.version }}
       annotations:
-        releasetime: {{ $.Release.Time }}
+        releasetime: {{ now }}
     spec:
       affinity:
         podAntiAffinity:

--- a/helm/dns-network-policy-operator/templates/psp.yaml
+++ b/helm/dns-network-policy-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{tpl .Values.resource.default.name  . }}
@@ -24,9 +24,4 @@ spec:
   hostPID: false
   hostIPC: false
   hostNetwork: false
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      - min: 1
-        max: 65535
   readOnlyRootFilesystem: false


### PR DESCRIPTION
Update architect-orb to 2.1.0 which will use giantswarm.github.io as catalog base url. The old behaviour was to use giantswarm.github.com which will be deprecated in april by GitHub. Towards giantswarm/giantswarm#15898