### PR TITLE
docs(docs/README): fix apiVersion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ spec:
 This policy allows an egress traffic to the DNS service only.
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy                                                                                                
 metadata:      
   name: example
@@ -87,7 +87,7 @@ After CR is created, `dns-network-policy-operator` resolves the listed domain an
 ```
 kubectl get networkpolicies example-active -o yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy                                 
 metadata:     
   annotations:                    


### PR DESCRIPTION
Hi

While looking at the documentation I was asking myself if this tool was still using `extensions/v1` as `apiVersion` for grabbing and creating the `NetworkPolicies`.

After further inspection of your code, I suggest changing the `docs/README.md` examples to make clear, that this operator is already using `networking.k8s.io/v1` and not the old `extensions/v1` apiVersion.

BR -- Toni

--
Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
